### PR TITLE
Trigger complete enumeration to avoid duplicated permutations

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -74,7 +74,7 @@
             message("'nperm' > set of all permutations; Resetting 'nperm'.")
     }
 
-    ## if number of possible perms < minperm or <= 8! turn on complete
+    ## if number of possible perms < minperm or <= 7! turn on complete
     ## enumeration
     if((num.pos < getMinperm(control))) {
         setComplete(control) <- TRUE
@@ -82,7 +82,7 @@
         setMaxperm(control) <- num.pos
         if(!quietly)
             message("Set of permutations < 'minperm'. Generating entire set.")
-    } else if (num.pos < 40321) {
+    } else if (num.pos < 5040.5) { # num.pos is not an integer!
         ## sample from complete enumeration but quietly and do not
         ## reset nperm
         setComplete(control) <- TRUE

--- a/R/check.R
+++ b/R/check.R
@@ -74,13 +74,19 @@
             message("'nperm' > set of all permutations; Resetting 'nperm'.")
     }
 
-    ## if number of possible perms < minperm turn on complete enumeration
+    ## if number of possible perms < minperm or <= 8! turn on complete
+    ## enumeration
     if((num.pos < getMinperm(control))) {
         setComplete(control) <- TRUE
         setNperm(control) <- num.pos
         setMaxperm(control) <- num.pos
         if(!quietly)
             message("Set of permutations < 'minperm'. Generating entire set.")
+    } else if (num.pos < 40321) {
+        ## sample from complete enumeration but quietly and do not
+        ## reset nperm
+        setComplete(control) <- TRUE
+        setMaxperm(control) <- num.pos
     }
 
     ## if complete enumeration, generate all permutations

--- a/R/check.R
+++ b/R/check.R
@@ -83,9 +83,8 @@
 
     ## if number of possible perms < minperm or <= 7! turn on complete
     ## enumeration
-    if((num.pos < getMinperm(control) + EPS)) {
+    if((num.pos - !getObserved(control) < getMinperm(control) + EPS)) {
         setComplete(control) <- TRUE
-        setNperm(control) <- num.pos
         setMaxperm(control) <- num.pos
         if(!quietly)
             message("Set of permutations < 'minperm'. Generating entire set.")

--- a/R/check.R
+++ b/R/check.R
@@ -71,9 +71,10 @@
     ## get number of possible permutations
     num.pos <- numPerms(object, control)
 
-    ## check if number requested permutations exceeds max possible
+    ## check if number requested permutations exceeds or equals max
+    ## possible
     nperm <- getNperm(control)
-    if(nperm + EPS > num.pos - 1) {
+    if(nperm + EPS > num.pos - !getObserved(control)) {
         setComplete(control) <- TRUE
         setMaxperm(control) <- num.pos
         if(!quietly)

--- a/R/check.R
+++ b/R/check.R
@@ -1,5 +1,11 @@
 `check` <- function(object, control = how(), quietly = FALSE)
 {
+    ## In pricinple we are mainly dealing with integers, but many
+    ## functions do not return integers but double, and the numbers
+    ## can be so large that they overflow integer and they really must be
+    ## double. Therefore we define EPS as a nice value between two
+    ## successive integers
+    EPS <- 0.5
     ## if object is numeric or integer and of length 1,
     ## extend the object
     if(length(object) == 1 &&
@@ -66,23 +72,23 @@
     num.pos <- numPerms(object, control)
 
     ## check if number requested permutations exceeds max possible
-    if(getNperm(control) > num.pos) {
+    nperm <- getNperm(control)
+    if(nperm + EPS > num.pos - 1) {
         setComplete(control) <- TRUE
-        setNperm(control) <- num.pos
         setMaxperm(control) <- num.pos
         if(!quietly)
-            message("'nperm' > set of all permutations; Resetting 'nperm'.")
+            message("'nperm' >= set of all permutations: complete enumeration.")
     }
 
     ## if number of possible perms < minperm or <= 7! turn on complete
     ## enumeration
-    if((num.pos < getMinperm(control))) {
+    if((num.pos < getMinperm(control) + EPS)) {
         setComplete(control) <- TRUE
         setNperm(control) <- num.pos
         setMaxperm(control) <- num.pos
         if(!quietly)
             message("Set of permutations < 'minperm'. Generating entire set.")
-    } else if (num.pos < 5040.5) { # num.pos is not an integer!
+    } else if (num.pos < 5040 + EPS) { # num.pos is not an integer!
         ## sample from complete enumeration but quietly and do not
         ## reset nperm
         setComplete(control) <- TRUE

--- a/R/check.R
+++ b/R/check.R
@@ -74,9 +74,10 @@
     ## check if number requested permutations exceeds or equals max
     ## possible
     nperm <- getNperm(control)
-    if(nperm + EPS > num.pos - !getObserved(control)) {
+    if(nperm + EPS > (num.pos - !getObserved(control))) {
         setComplete(control) <- TRUE
         setMaxperm(control) <- num.pos
+        setNperm(control) <- num.pos - !getObserved(control)
         if(!quietly)
             message("'nperm' >= set of all permutations: complete enumeration.")
     }

--- a/R/check.R
+++ b/R/check.R
@@ -81,18 +81,13 @@
             message("'nperm' >= set of all permutations: complete enumeration.")
     }
 
-    ## if number of possible perms < minperm or <= 7! turn on complete
+    ## if number of possible perms < minperm turn on complete
     ## enumeration
-    if((num.pos - !getObserved(control) < getMinperm(control) + EPS)) {
+    if((num.pos - !getObserved(control)) < getMinperm(control) + EPS) {
         setComplete(control) <- TRUE
         setMaxperm(control) <- num.pos
         if(!quietly)
             message("Set of permutations < 'minperm'. Generating entire set.")
-    } else if (num.pos < 5040 + EPS) { # num.pos is not an integer!
-        ## sample from complete enumeration but quietly and do not
-        ## reset nperm
-        setComplete(control) <- TRUE
-        setMaxperm(control) <- num.pos
     }
 
     ## if complete enumeration, generate all permutations

--- a/R/how.R
+++ b/R/how.R
@@ -4,7 +4,7 @@
                   nperm = 199,
                   complete = FALSE,
                   maxperm = 9999,
-                  minperm = 99,
+                  minperm = 5040,
                   all.perms = NULL,
                   make = TRUE,
                   observed = FALSE) {

--- a/R/print.how.R
+++ b/R/print.how.R
@@ -77,7 +77,7 @@
 
     ## Meta data
     writeLines("Permutation details:")
-    writeLines(strwrap(paste("Number of permutations requested:",
+    writeLines(strwrap(paste("Number of permutations:",
                              getNperm(x)), prefix = pfix))
     writeLines(strwrap(paste("Max. number of permutations allowed:",
                              getMaxperm(x)), prefix = pfix))

--- a/man/check.Rd
+++ b/man/check.Rd
@@ -43,10 +43,12 @@ check(object, control = how(), quietly = FALSE)
   and complete enumeration of all permutations is turned on
   (\code{control$complete} is set to \code{TRUE}). 
 
-  Alternatively, if the number of possible permutations is low, and less
-  than \code{control$minperm}, it is better to enumerate all possible
-  permutations, and as such complete enumeration of all permutations is
-  turned  on (\code{control$complete} is set to \code{TRUE}).
+  Alternatively, if the number of possible permutations is low, and
+  less than \code{control$minperm}, it is better to enumerate all
+  possible permutations, and as such complete enumeration of all
+  permutations is turned on (\code{control$complete} is set to
+  \code{TRUE}). This guarantees that permutations are all unique and
+  there are no duplicates.
 }
 \value{
   For \code{check} a list containing the maximum number of

--- a/man/how.Rd
+++ b/man/how.Rd
@@ -16,7 +16,7 @@
 \usage{
 how(within = Within(), plots = Plots(), blocks = NULL,
     nperm = 199, complete = FALSE, maxperm = 9999,
-    minperm = 99, all.perms = NULL, make = TRUE,
+    minperm = 5040, all.perms = NULL, make = TRUE,
     observed = FALSE)
 
 Within(type = c("free","series","grid","none"),
@@ -43,10 +43,12 @@ Plots(strata = NULL, type = c("none","free","series","grid"),
     \code{"free"}, \code{"series"}, \code{"grid"} or \code{"none"}. See
     Details.} 
   \item{maxperm}{numeric; the maximum number of permutations to
-    perform. Currently unused.} 
+    perform. Currently unused.}
   \item{minperm}{numeric; the lower limit to the number of possible
-    permutations at which complete enumeration is performed. See argument
-    \code{complete} and Details, below.} 
+    permutations at which complete enumeration is performed. When
+    \code{nperm} is lower than \code{minperm}, sampling is performed
+    from complete permutations to avoid duplicated permutations. See
+    argument \code{complete} and Details, below.}
   \item{all.perms}{an object of class \code{allPerms}, the result of a
     call to \code{\link{allPerms}}.}
   \item{make}{logical; should \code{check} generate all possible


### PR DESCRIPTION
This PR sets sampling form complete permutations when the number of possible permutations is 7! = 5040. This is done via `minperm` argument in `how()` so that users can easily reset the option. The 7! limit corresponds to random permutation of 7 (!) sampling units. With `n=7` and `nperm=999` we typically get about 10% duplicated permutations without this option.

The general rules after this PR are:
- If the user asks more than the maximum number of unique permutations, then `nperm` will be reset and the complete enumeration is returned (this more or less happened earlier).
- If the user asks the correct maximum number of unique permutations, the requested complete enumeration is returned (this is new).
- If the maximum number of unique permutation is low (defaults `minperm = 5040`) but higher than the requested number, sampling is made from the complete enumeration to guarantee unique permutations (this is new).

In addition, the following quirks were changed:
- The number of possible permutations is one lower if the original order is not included which is the default (`how(observed = FALSE)`). 
- Sometimes we deliver a lower number than requested and now we are more modest in printing the description of `how()`.
- If we update `nperm` or `maxperm` we also  update  the description of `how()`. 

The fixes are also compatible with `vegan:::howHead()`. 
