### PR TITLE
It should be possible to suppress check messages in shuffleSet

### DIFF
--- a/R/shuffleSet2.R
+++ b/R/shuffleSet2.R
@@ -1,5 +1,7 @@
 ## new version of shuffleSet() that allows for blocking
-`shuffleSet` <- function(n, nset, control = how(), check = TRUE) {
+`shuffleSet` <-
+    function(n, nset, control = how(), check = TRUE, quietly = FALSE)
+{
     ## Store the .Random.seed, if it exists, so we can attach this as
     ## an attribute to the permutation matrix returned in out
     SEED <- NULL
@@ -27,7 +29,7 @@
     ## yourself in the foot with this, hence the default is to check!
     if (isTRUE(check)) {
         ## need to check number of permutations won't blow up
-        pcheck <- check(sn, control = control)
+        pcheck <- check(sn, control = control, quietly = quietly)
         ## control possibly now updated
         control <- pcheck$control
     }

--- a/man/shuffleSet.Rd
+++ b/man/shuffleSet.Rd
@@ -11,7 +11,7 @@
   set of permutations.
 }
 \usage{
-shuffleSet(n, nset, control = how(), check = TRUE)
+shuffleSet(n, nset, control = how(), check = TRUE, quietly = FALSE)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -33,6 +33,7 @@ shuffleSet(n, nset, control = how(), check = TRUE)
     the stated number of observations and update \code{control}
     accordingly. See Details.
   }
+  \item{quietly}{logical; should messages by suppressed?}
 }
 \details{
   \code{shuffleSet} is designed to generate a set of \code{nset}


### PR DESCRIPTION
Currently, `shuffleSet` does not pass `quietly` argument to `check` which makes the whole argument a bit useless: who uses `check() directly and does not want messages?