### PR TITLE
Do not drop dimensions of 1-permutation matrix

### DIFF
--- a/R/allPerms.R
+++ b/R/allPerms.R
@@ -70,7 +70,7 @@
     if(!(observed <- getObserved(control))) {
         obs.v <- seq_len(n)
         obs.row <- apply(out, 1, function(x, obs.v) all(x == obs.v), obs.v)
-        out <- out[!obs.row, ]
+        out <- out[!obs.row, , drop = FALSE]
         ## reduce the number of permutations to get rid of the
         ## observed ordering
         setNperm(control) <- getNperm(control) - 1


### PR DESCRIPTION
shuffleSet(2) should give a row-vector [2 1], but it gave a
column vector. This breaks applications where we assume that
rows always give permutations, such as vegan:::nesteddisc().