### PR TITLE
fix plot-level grid validation in check()

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -54,9 +54,9 @@
         ## if permuting Plots as a grid check dimensions match levels of
         ## Plot-level strata
         if(isTRUE(all.equal(typeP, "grid"))) {
-            levP <- levels(Plots)
+            levP <- length(levels(plots))
             dimP <- getDim(control, which = "plots")
-            if(!identical(levP, prod(dimP))) {
+            if(!isTRUE(all.equal(levP, prod(dimP)))) {
                 stop("Plot 'nrow' * 'ncol' not a multiple of number of Plots.")
             }
         }

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -34,3 +34,25 @@ test_that("check detects if nothing to permute", {
     expect_error(check(seq_len(n), control = h),
                  regexp = "Permutation 'type' is \"none\" for both 'plots' & 'within'.\nNothing to permute.")
 })
+
+## test that check accepts a valid plot-level grid design and rejects
+## one whose grid dimensions do not match the number of Plots (see the
+## bug where 'levels(Plots)' returned NULL for every design)
+test_that("check accepts a valid plot-level grid design", {
+    ## 9 Plots arranged as a 3 x 3 grid; 25 observations per Plot
+    pl <- gl(9, 25)
+    n <- length(pl)
+    h <- how(within = Within(type = "free"),
+             plots = Plots(strata = pl, type = "grid", nrow = 3, ncol = 3))
+    expect_that(check(seq_len(n), control = h), is_a("check"))
+})
+
+test_that("check rejects a plot-level grid design with mismatched dimensions", {
+    ## only 4 Plots, but the grid is 3 x 3 == 9 cells
+    pl <- gl(4, 9)
+    n <- length(pl)
+    h <- how(within = Within(type = "free"),
+             plots = Plots(strata = pl, type = "grid", nrow = 3, ncol = 3))
+    expect_error(check(seq_len(n), control = h),
+                 regexp = "Plot 'nrow' \\* 'ncol' not a multiple of number of Plots.")
+})


### PR DESCRIPTION
check() rejected every valid plot-level grid design: it compared prod(nrow * ncol) against levels(Plots), but Plots is the constructor function, so levels(Plots) is always NULL.

Use length(levels(plots)) for the number of plot strata (matching the idiom used in numPerms()), and compare via isTRUE(all.equal()): the level count is integer while prod(getDim()) is double, so identical() would still fail for every valid design even after correcting the variable name.

Add regression tests covering a valid plot-level grid design (9 Plots in a 3x3 grid) and a mismatched one (4 Plots, 3x3 grid).

Found during my large https://github.com/sims1253/ry audit